### PR TITLE
Update Package.json Node Engine for Heroku Build Error Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "express": "3.x"
   },
   "engines": {
-  	"node": "12.14.0"
+  	"node": "12.14.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "express": "3.x"
   },
   "engines": {
-  	"node": "0.10.x"
+  	"node": "12.14.0"
   }
 }


### PR DESCRIPTION
Heroku seems to randomly experience build errors when deploying this lab. This appears to be the case because the node engine version is at 0.10.x, which is too low. See [this article](https://stackoverflow.com/questions/49838216/nodemon-not-running-due-to-requires-update-notifier-package) for more details.

This pull request updates the node engine version to fix Heroku builds. 